### PR TITLE
fix: stop configure-pages from injecting Nuxt 2 config properties

### DIFF
--- a/.github/workflows/nuxtjs.yml
+++ b/.github/workflows/nuxtjs.yml
@@ -53,12 +53,6 @@ jobs:
           cache: ${{ steps.detect-package-manager.outputs.manager }}
       - name: Setup Pages
         uses: actions/configure-pages@v5
-        with:
-          # Automatically inject router.base in your Nuxt configuration file and set
-          # target to static (https://nuxtjs.org/docs/configuration-glossary/configuration-target/).
-          #
-          # You may remove this line if you want to manage the configuration yourself.
-          static_site_generator: nuxt
       - name: Restore cache
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
actions/configure-pages with static_site_generator: nuxt injects router.base and target: static into nuxt.config.js. Both are Nuxt 2 options that no longer exist in Nuxt 3. The action's config parser throws a bare string when it can't resolve the injection, which causes TypeError: error must be an instance of Error and the build never reaches nuxt generate.

Removing static_site_generator: nuxt stops the injection entirely. Also adds public/.nojekyll so GitHub Pages doesn't hide _nuxt/ assets.

Closes #78